### PR TITLE
Refactor client to use multiple inheritance

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -13,15 +13,6 @@ class TestClient(object):
         auth = mock.Mock()
         cls.client = Client(auth)
 
-    def test_add_instance_methods(self):
-        methods = [
-            ('_private', 'private_method'),
-            ('public', 'public_method')
-        ]
-        self.client._add_instance_methods(methods)
-        assert self.client.public == 'public_method'
-        assert not hasattr(self.client, '_private')
-
     def test_make_connection_closes(self):
         mock_conn = mock.Mock()
         mock_conn.read.return_value = b'{}'
@@ -49,5 +40,5 @@ class TestClient(object):
 
         with mock.patch('six.moves.urllib.request.urlopen', side_effect=error):
             with mock.patch('yelp.errors.ErrorHandler.raise_error') as r:
-                self.client._make_request("")
+                self.client.make_request("")
                 r.assert_called_once_with(error)

--- a/tests/endpoint/business_test.py
+++ b/tests/endpoint/business_test.py
@@ -13,14 +13,14 @@ class TestBusiness(object):
         cls.client = Client(auth)
 
     def test_get_business_builds_correct_params(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             request.return_value = '{}'
             response = self.client.get_business('test-id')
             request.assert_called_once_with('/v2/business/test-id', {})
             assert type(response) is BusinessResponse
 
     def test_get_business_builds_correct_params_with_lang(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             params = {'lang': 'fr'}
             self.client.get_business('test-id', **params)
             request.assert_called_once_with('/v2/business/test-id', params)

--- a/tests/endpoint/phone_search_test.py
+++ b/tests/endpoint/phone_search_test.py
@@ -13,7 +13,7 @@ class TestBusiness(object):
         cls.client = Client(auth)
 
     def test_phone_search_builds_correct_params(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             request.return_value = '{}'
             params = {
                 'category': 'fashion'

--- a/tests/endpoint/search_test.py
+++ b/tests/endpoint/search_test.py
@@ -15,7 +15,7 @@ class TestBusiness(object):
         cls.client = Client(auth)
 
     def test_search_builds_correct_params(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             request.return_value = '{}'
             params = {
                 'term': 'food',
@@ -28,7 +28,7 @@ class TestBusiness(object):
             assert type(response) is SearchResponse
 
     def test_search_builds_correct_params_with_current_lat_long(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             params = {
                 'term': 'food',
             }
@@ -40,7 +40,7 @@ class TestBusiness(object):
             request.assert_called_once_with('/v2/search/', params)
 
     def test_search_by_bounding_box_builds_correct_params(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             params = {
                 'term': 'food',
             }
@@ -49,6 +49,6 @@ class TestBusiness(object):
             request.assert_called_once_with('/v2/search/', params)
 
     def test_search_by_coordinates_builds_correct_params(self):
-        with mock.patch('yelp.client.Client._make_request') as request:
+        with mock.patch('yelp.client.BaseClient.make_request') as request:
             self.client.search_by_coordinates(0, 0, 0, 0, 0)
             request.assert_called_once_with('/v2/search/', {'ll': '0,0,0,0,0'})

--- a/yelp/client.py
+++ b/yelp/client.py
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-import inspect
 import json
 
 import six
@@ -11,35 +10,13 @@ from yelp.endpoint.search import Search
 from yelp.errors import ErrorHandler
 
 
-class Client(object):
-
-    _endpoints = [
-        Business,
-        PhoneSearch,
-        Search
-    ]
+class BaseClient(object):
 
     def __init__(self, authenticator):
         self.authenticator = authenticator
         self._error_handler = ErrorHandler()
-        self._define_request_methods()
 
-    # Creates an instance of each endpoint class and adds the instances' public
-    # singleton methods to Client. We do this to promote modularity.
-    def _define_request_methods(self):
-        endpoint_instances = [end(self) for end in self._endpoints]
-        for endpoint in endpoint_instances:
-            instance_methods = inspect.getmembers(endpoint, inspect.ismethod)
-            self._add_instance_methods(instance_methods)
-
-    def _add_instance_methods(self, instance_methods):
-        # instance_methods is a list of (name, value) tuples where value is the
-        # instance of the bound method
-        for method in instance_methods:
-            if method[0][0] is not '_':
-                self.__setattr__(method[0], method[1])
-
-    def _make_request(self, path, url_params={}):
+    def make_request(self, path, url_params={}):
         url = 'https://{0}{1}?'.format(
             API_HOST,
             six.moves.urllib.parse.quote(path.encode('utf-8'))
@@ -58,3 +35,7 @@ class Client(object):
             finally:
                 conn.close()
             return response
+
+
+class Client(BaseClient, Business, PhoneSearch, Search):
+    pass

--- a/yelp/endpoint/business.py
+++ b/yelp/endpoint/business.py
@@ -5,9 +5,6 @@ from yelp.obj.business_response import BusinessResponse
 
 class Business(object):
 
-    def __init__(self, client):
-        self.client = client
-
     def get_business(self, business_id, **url_params):
         """Make a request to the business endpoint. More info at
         https://www.yelp.com/developers/documentation/v2/business
@@ -23,5 +20,5 @@ class Business(object):
         """
         business_path = BUSINESS_PATH + business_id
         return BusinessResponse(
-            self.client._make_request(business_path, url_params)
+            self.make_request(business_path, url_params)
         )

--- a/yelp/endpoint/phone_search.py
+++ b/yelp/endpoint/phone_search.py
@@ -5,9 +5,6 @@ from yelp.obj.search_response import SearchResponse
 
 class PhoneSearch(object):
 
-    def __init__(self, client):
-        self.client = client
-
     def phone_search(self, phone, **url_params):
         """Make a request to the phone search endpoint.More info at
         https://www.yelp.com/developers/documentation/v2/phone_search
@@ -24,5 +21,5 @@ class PhoneSearch(object):
         url_params['phone'] = phone
 
         return SearchResponse(
-            self.client._make_request(PHONE_SEARCH_PATH, url_params)
+            self.make_request(PHONE_SEARCH_PATH, url_params)
         )

--- a/yelp/endpoint/search.py
+++ b/yelp/endpoint/search.py
@@ -5,9 +5,6 @@ from yelp.obj.search_response import SearchResponse
 
 class Search(object):
 
-    def __init__(self, client):
-        self.client = client
-
     def search(
         self,
         location,
@@ -41,7 +38,7 @@ class Search(object):
             )
 
         return SearchResponse(
-            self.client._make_request(SEARCH_PATH, url_params)
+            self.make_request(SEARCH_PATH, url_params)
         )
 
     def search_by_bounding_box(
@@ -76,7 +73,7 @@ class Search(object):
         )
 
         return SearchResponse(
-            self.client._make_request(SEARCH_PATH, url_params)
+            self.make_request(SEARCH_PATH, url_params)
         )
 
     def search_by_coordinates(
@@ -115,7 +112,7 @@ class Search(object):
         )
 
         return SearchResponse(
-            self.client._make_request(SEARCH_PATH, url_params)
+            self.make_request(SEARCH_PATH, url_params)
         )
 
     def _format_current_lat_long(self, lat, long):


### PR DESCRIPTION
Attempt to fix #33. Uses the idea of a LowLevelClient as @mittonk suggested in the thread.

Structure based on [octokit](https://github.com/octokit/octokit.py/tree/master/octokit). The endpoints are still modular but the Client class inherits from them rather than dynamically copying methods. Note that helper methods are now accessible.

cc @asottile @tomelm 
