### PR TITLE
Errors should be more explicit. Closes #44.

### DIFF
--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -6,6 +6,7 @@ import pytest
 import six
 
 from tests.testing import resource_filename
+from yelp import errors
 from yelp.errors import ErrorHandler
 from yelp.errors import InvalidParameter
 
@@ -39,3 +40,56 @@ class TestErrorHandler(object):
         with pytest.raises(InvalidParameter) as err:
             self.handler.raise_error(error)
         assert "radius_filter" in err.value.text
+
+
+def _verify_error_message(error_cls):
+    code = 400
+    msg = 'Bad Request'
+    resp = {
+        'error': {
+            'text': 'One or more parameters are invalid in request',
+            'id': 'INVALID_PARAMETER',
+            'field': 'term'
+        }
+    }
+    err = error_cls(code, msg, resp)
+    message = str(err)
+    assert str(code) in message
+    assert msg in message
+    assert resp['error']['text'] in message
+    return message
+
+
+def test_yelp_error():
+    """Error messages should contain the useful elements of the
+    error response.
+    """
+    message = _verify_error_message(errors.YelpError)
+    # Pinning down something we don't currently include, though we could.
+    assert 'term' not in message
+
+
+def test_invalid_parameter():
+    """InvalidParameter should also list the offending field."""
+    message = _verify_error_message(errors.InvalidParameter)
+    assert 'term' in message
+
+
+def test_error_message_handles_unicode():
+    """We should at least print recognizable forms of the errors.
+    The less mangling we do the better, but some repr() might make sense.
+    """
+    code = 400
+    msg = u'Bäd'
+    resp = {
+        'error': {
+            'text': u'Wröng',
+            'id': u'ERRØR',
+            'field': u'tërm'
+        }
+    }
+    err = errors.YelpError(code, msg, resp)
+    message = str(err)
+    assert str(code) in message
+    assert repr(msg) in message
+    assert repr(resp['error']['text']) in message

--- a/yelp/errors.py
+++ b/yelp/errors.py
@@ -11,6 +11,14 @@ class YelpError(Exception):
         self.id = response['error']['id']
         self.text = response['error']['text']
 
+    def __str__(self):
+        return repr({
+            'code': self.code,
+            'msg': self.msg,
+            'id': self.id,
+            'text': self.text,
+        })
+
 
 class AreaTooLarge(YelpError):
     pass


### PR DESCRIPTION
With this branch:
```
$ python foo.py 
Traceback (most recent call last):
  File "foo.py", line 13, in <module>
    response = client.search('San Francisco', term=u'ș'.encode('utf8'))
  File "/nail/home/kmitton/pg/other/yelp-python/yelp/endpoint/search.py", line 44, in search
    self.client._make_request(SEARCH_PATH, url_params)
  File "/nail/home/kmitton/pg/other/yelp-python/yelp/client.py", line 48, in _make_request
    return self._make_connection(signed_url)
  File "/nail/home/kmitton/pg/other/yelp-python/yelp/client.py", line 54, in _make_connection
    self._error_handler.raise_error(error)
  File "/nail/home/kmitton/pg/other/yelp-python/yelp/errors.py", line 107, in raise_error
    response
yelp.errors.InvalidParameter: {'msg': 'Bad Request', 'text': u'One or more parameters are invalid in request: term', 'code': 400, 'id': u'INVALID_PARAMETER'}
```

Compared to `master`:
```
...
yelp.errors.InvalidParameter:
```

`tox` green on 2.7 and 3.4 with my credentials in `tests/json/credentials_secret.json` for integration testing, and relatively-green without those creds.